### PR TITLE
Use Markdown headers for issue template sections

### DIFF
--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -9,8 +9,8 @@ assignees: ''
 
 ## Discussion
 
-**What do you want to talk about?**
+#### What do you want to talk about?
 A clear and concise description of the discussion you want, and why you want it.
 
-**Relevant resources**
+#### Relevant Resources / Research
 A list of anything you think someone should look at in order to engage.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -9,15 +9,15 @@ assignees: ''
 
 ## Feature Request
 
-**Is your feature request related to a problem? Please describe.**
+#### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I have an issue when [...]
 
-**Describe the solution you'd like**
+#### Describe the solution you'd like
 A clear and concise description of what you want to happen. Add any considered drawbacks.
 
-**Describe alternatives you've considered**
+#### Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Teachability, Documentation, Adoption, Migration Strategy**
+#### Teachability, Documentation, Adoption, Migration Strategy
 If you can, explain how users will be able to use this and possibly write out a version the docs.
 Maybe a screenshot or design?

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,6 +1,6 @@
 ---
 name: "\U00002692 Team Task"
-about: "Something needs doing"
+about: "Something needs doing."
 title: ''
 labels: 'i: needs triage'
 assignees: ''
@@ -9,11 +9,11 @@ assignees: ''
 
 ## Task
 
-**Description**
+#### Description
 A clear and concise description of what needs to be done
 
-**Relevant resources / research**
+#### Relevant Resources / Research
 Any links or ideas that you've already collected related to the task
 
-**Related Issues**
+#### Related Issues
 A list of related issues


### PR DESCRIPTION
This replaces the simple bolded text with `####` (H4) headers, which render in a similar size w/in GitHub but add consistent margin between the header and the following content. (Otherwise, whether the next line of text appeared directly below the header or not would depend on if the contributor entered a newline between them or not, and that’s just sloppy.)

It also adds a much-needed period to one of the descriptions.

For some reason, opening this PR didn't prefill with the PR template. But in any case, it's just a GitHub-specific issue template change with no associated issue.