### PR TITLE
Configure Jest to support absolute imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,5 @@
-const package = require('./package.json')
+const { getModuleAliasesForESLint } = require('./lib/utils/moduleAlias')
 
-const extractModuleAliasesFromPackage = (package) => {
-	const aliasStems = Object.keys(package._moduleAliases)
-	return aliasStems.map(
-		(stem) => [stem, package._moduleAliases[stem]]
-	)
-}
-const aliases = extractModuleAliasesFromPackage(package)
 const settings = {
 	"extends": "airbnb-base",
 	"parser": "babel-eslint",
@@ -22,7 +15,7 @@ const settings = {
 	},
 	"settings": {
 		"import/resolver": {
-			"alias": aliases
+			"alias": getModuleAliasesForESLint()
 		}
 	}
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+const { getModuleAliasesForJest } = require('./lib/utils/moduleAlias')
+
+const settings = {
+	moduleNameMapper: getModuleAliasesForJest(),
+}
+
+module.exports = settings

--- a/lib/utils/moduleAlias.js
+++ b/lib/utils/moduleAlias.js
@@ -1,0 +1,21 @@
+// Require our actual `package.json` data for use by this file.
+//
+// NB: `package` is a reserved word
+const packageData = require('../../package.json')
+
+// Extracts and returns the `module-alias` configuration from our `package.json` data.
+//
+// We don't control the `_moduleAliases` variable name, we just work with it.
+// eslint-disable-next-line no-underscore-dangle
+const getModuleAliasesFromPackage = () => packageData._moduleAliases || {}
+
+// Loads aliases from our `package.json` data and returns them, transformed into ESLint's
+// configuration format: `[[alias, destination]]`.
+const getModuleAliasesForESLint = () => {
+	const moduleAliases = getModuleAliasesFromPackage()
+	return Object.keys(moduleAliases).map((stem) => [stem, moduleAliases[stem]])
+}
+
+module.exports = {
+	getModuleAliasesForESLint,
+}

--- a/lib/utils/moduleAlias.js
+++ b/lib/utils/moduleAlias.js
@@ -1,23 +1,42 @@
-// Require our actual `package.json` data for use by this file.
-//
-// NB: `package` is a reserved word
+/**
+ * Require our actual `package.json` data for use by this file.
+ *
+ * (NB: `package` is a reserved word.)
+ */
 const packageData = require('../../package.json')
 
-// Extracts and returns the `module-alias` configuration from our `package.json` data.
-//
+/**
+ * Extracts the `module-alias` configuration settings from our `package.json` data.
+ *
+ * Since this will be in a syntax specific to the `module-alias` package, this data will almost
+ * certainly have to be transformed for use by other packages/tools.
+ *
+ * @returns {Object} The `module-alias` configuration, with alias as key and destination as value,
+ *                   or an empty object.
+ */
 // We don't control the `_moduleAliases` variable name, we just work with it.
 // eslint-disable-next-line no-underscore-dangle
 const getModuleAliasesFromPackage = () => packageData._moduleAliases || {}
 
-// Loads aliases from our `package.json` data and returns them, transformed into ESLint's
-// configuration format: `[[alias, destination]]`.
+/**
+ * Loads aliases from `package.json` data and transforms them into ESLint's configuration format:
+ * `[[alias, destination]]`
+ *
+ * @returns {Array[]} An array of arrays, where each inner array is an alias/destination mapping
+ *                    with the alias in the first position and the destination in the second.
+ */
 const getModuleAliasesForESLint = () => {
 	const moduleAliases = getModuleAliasesFromPackage()
 	return Object.keys(moduleAliases).map((stem) => [stem, moduleAliases[stem]])
 }
 
-// Loads aliases from our `package.json` data and returns them, transformed into Jest's
-// configuration format: `{ alias: destination }`.
+/**
+ * Loads aliases from `package.json` data and transforms them into Jest's configuration format:
+ * `{ alias: destination }`
+ *
+ * @returns {Object} An object containing the aliases and destinations, with each alias as a key
+ *                   and its corresponding destination as the value.
+ */
 const getModuleAliasesForJest = () => {
 	const moduleAliases = getModuleAliasesFromPackage()
 	return Object.keys(moduleAliases).reduce((accumulator, alias) => {

--- a/lib/utils/moduleAlias.js
+++ b/lib/utils/moduleAlias.js
@@ -16,6 +16,23 @@ const getModuleAliasesForESLint = () => {
 	return Object.keys(moduleAliases).map((stem) => [stem, moduleAliases[stem]])
 }
 
+// Loads aliases from our `package.json` data and returns them, transformed into Jest's
+// configuration format: `{ alias: destination }`.
+const getModuleAliasesForJest = () => {
+	const moduleAliases = getModuleAliasesFromPackage()
+	return Object.keys(moduleAliases).reduce((accumulator, alias) => {
+		const transformedAlias = {
+			alias: `^${alias}(.*)$`,
+			destination: `${moduleAliases[alias].replace('./', '<rootDir>/')}$1`,
+		}
+		return {
+			...accumulator,
+			[transformedAlias.alias]: transformedAlias.destination,
+		}
+	}, {})
+}
+
 module.exports = {
 	getModuleAliasesForESLint,
+	getModuleAliasesForJest,
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "kafka": "yarn kafka:start",
     "kafka:start": "./services/kafka/start.sh",
     "kafka:stop": "./services/kafka/stop.sh",
-    "lint": "./node_modules/.bin/eslint 'src/**/*.js'",
+    "lint": "./node_modules/.bin/eslint 'src/**/*.js' 'lib/**/*.js'",
     "sandbox": "babel-node -- src/scripts/_sandbox",
     "start": "yarn babel-node src/index.js",
     "test": "jest"


### PR DESCRIPTION
## Description
We use `module-alias` to let us absolutely import modules from defined roots. However, Jest doesn’t pick up these defined roots automatically; instead, we need to replicate them in our Jest configuration.

This PR adds that configuration. Note that Jest uses regex and suggests you include beginning/end anchors for explicitness, so we do.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Deploy Notes
None.

## Related Issues
Resolves #35