### PR TITLE
Demonstrate ffmpeg proxying of external to internal stream

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,16 @@ LOG_LEVEL=info
 
 # A comma-delimited list of Kafka brokers
 KAFKA_BROKERS=localhost:9092
+
+# The address and port range pool for the internal streams. The ingester will compose an address
+# from this pool for streaming its output to the countertop. Note that number of available ports is
+# effectively the cap on number of simultaneous streams.
+#
+# Set address to an IP address or `localhost`:
+INTERNAL_STREAM_ADDRESS=localhost
+# Set the port ranges for the stream pool. This can be a comma-delimited list, a hyphen-delimited
+# range, or a combination of both, e.g.:
+# - `23000,23001,23002`
+# - `23000-23002` (same)
+# - `23000-23002,23010-23012` (same, plus ports 23010-23012)
+INTERNAL_STREAM_PORT_RANGE=23000-23010

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,6 +4,7 @@
 
 - [Node.js](https://nodejs.org/). The required version of Node.js is documented in the `package.json`. We recommend installing a tool for managing versions of Node.js on your development machine; several of our contributors use [nvm](https://nvm.sh), though we don't specifically require it.
 - [Yarn](https://yarnpkg.com/) for package management.
+- [FFmpeg](https://ffmpeg.org/) for processing audio/video streams. Be sure FFmpeg is available in your `$PATH` so that Node.js can call it.
 
 Steps for installing prerequisites are excluded since different developers/environments will have different preferences. Follow your system-specific instructions for each prerequisite.
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "./node_modules/.bin/eslint 'src/**/*.js' 'lib/**/*.js'",
     "sandbox": "babel-node -- src/scripts/_sandbox",
     "start": "yarn babel-node src/index.js",
-    "test": "jest"
+    "test": "jest",
+    "ingest:showInternalStreamPool": "babel-node -- src/scripts/showInternalStreamPool"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "sandbox": "babel-node -- src/scripts/_sandbox",
     "start": "yarn babel-node src/index.js",
     "test": "jest",
+    "ingest": "babel-node -- src/scripts/ingest",
     "ingest:showInternalStreamPool": "babel-node -- src/scripts/showInternalStreamPool"
   },
   "repository": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,11 @@
 import dotenv from 'dotenv'
 
+import { expandRangeOfIntegers } from '%src/lib/utils'
+
 dotenv.config()
+
 export default {
-	KAFKA_BROKERS: process.env.KAFKA_BROKERS.split(','),
 	...process.env,
+	KAFKA_BROKERS: process.env.KAFKA_BROKERS.split(','),
+	INTERNAL_STREAM_PORT_RANGE: expandRangeOfIntegers(process.env.INTERNAL_STREAM_PORT_RANGE),
 }

--- a/src/lib/utils/__test__/index.test.js
+++ b/src/lib/utils/__test__/index.test.js
@@ -1,0 +1,69 @@
+import {
+	expandRangeOfIntegers,
+	generateIntegersBetween,
+	splitRangeToIntegers,
+	uniqueArray,
+} from '..'
+
+describe('utils/index', () => {
+	describe('expandRangeOfIntegers', () => {
+		const expectedRange = [1, 2, 3, 4, 5, 6]
+		it('Should expand known range examples to an array of integers', () => {
+			expect(expandRangeOfIntegers('1')).toEqual([1])
+			expect(expandRangeOfIntegers('1-1')).toEqual([1])
+			expect(expandRangeOfIntegers('1,2,3,4,5,6')).toEqual(expectedRange)
+			expect(expandRangeOfIntegers('1-6')).toEqual(expectedRange)
+			expect(expandRangeOfIntegers('1-3,4-6')).toEqual(expectedRange)
+			expect(expandRangeOfIntegers('1-3,4-6')).toEqual(expectedRange)
+			expect(expandRangeOfIntegers('1-3,4,5-6')).toEqual(expectedRange)
+		})
+		it('Should exclude duplicates', () => {
+			expect(expandRangeOfIntegers('1-6,1-6')).toEqual(expectedRange)
+		})
+	})
+	describe('generateIntegersBetween', () => {
+		it('Should generate integers between two integers', () => {
+			expect(generateIntegersBetween(0, 2)).toEqual([0, 1, 2])
+			expect(generateIntegersBetween(2, 0)).toEqual([2, 1, 0])
+			expect(generateIntegersBetween(-1, 1)).toEqual([-1, 0, 1])
+			expect(generateIntegersBetween(1, -1)).toEqual([1, 0, -1])
+		})
+		it('Should respect the `inclusive` option', () => {
+			expect(generateIntegersBetween(0, 2, { inclusive: false })).toEqual([1])
+		})
+		it('Should return an empty array if passed any non-integer arguments', () => {
+			expect(generateIntegersBetween('0', '2')).toEqual([])
+			expect(generateIntegersBetween(0, '2')).toEqual([])
+			expect(generateIntegersBetween('0', 2)).toEqual([])
+			expect(generateIntegersBetween('0')).toEqual([])
+			expect(generateIntegersBetween(0)).toEqual([])
+			expect(generateIntegersBetween()).toEqual([])
+		})
+		it('Should return a single-item array if passed equal arguments', () => {
+			expect(generateIntegersBetween(2, 2)).toEqual([2])
+		})
+		it('Should return an empty array if passed equal arguments with `inclusive: false`', () => {
+			expect(generateIntegersBetween(2, 2, { inclusive: false })).toEqual([])
+		})
+	})
+	describe('splitRangeToIntegers', () => {
+		it('Should split expected ranges to arrays of integers', () => {
+			expect(splitRangeToIntegers('1-3')).toEqual([1, 3])
+			expect(splitRangeToIntegers('3-1')).toEqual([3, 1])
+			expect(splitRangeToIntegers('1')).toEqual([1])
+		})
+		it('Should choke on badly-formatted arguments', () => {
+			// TODO: It'd be nice if we'd throw errors or otherwise usefully choke on weird input,
+			//       like `'1-3-6'` or `'hi-mom'`.
+		})
+	})
+	describe('uniqueArray', () => {
+		it('Should reduce an array to only its unique items', () => {
+			expect(uniqueArray([1, 1, 2])).toEqual([1, 2])
+			expect(uniqueArray([1, '1', 2])).toEqual([1, '1', 2])
+			expect(uniqueArray([1, 2])).toEqual([1, 2])
+			expect(uniqueArray([1])).toEqual([1])
+			expect(uniqueArray([])).toEqual([])
+		})
+	})
+})

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -1,0 +1,106 @@
+// ------------------------------------------------------------------------------------------------
+// NB: There are several places in this file that we'd like to use the logger, but unfortunately,
+// importing it creates a cyclical dependency (since this file is imported by config.js which is
+// imported by logger.js). I've indicated places below where we would like to log, if we ever sort
+// out how to safely do so.
+// ------------------------------------------------------------------------------------------------
+
+// Given an array of items, returns a new array with only the unique items.
+//
+// TODO: This could have quite a bit more safety and error-checking built in.
+export const uniqueArray = (array) => [...new Set(array)]
+
+// Given two integers, generates all the integers in between.
+//
+// By default, will include the original two boundary integers. To exclude them, set
+// `inclusive: false` in the third (options) argument.
+//
+// This function does not do type coercion, so boundary arguments must be integers.
+export const generateIntegersBetween = (a, b, { inclusive = true } = {}) => {
+	// Bail out early if we weren't passed integers
+	if (!Number.isInteger(a) || !Number.isInteger(b)) {
+		// TODO: Enable the next line if logger-importing is solved:
+		// logger.warn('generateIntegersBetween() requires the first two arguments to be integers.')
+		return []
+	}
+
+	// Bail out early if they're the same number
+	if (a === b) {
+		return inclusive ? [a] : []
+	}
+
+	// Fill that range up! (NB: This is written for clarity, not succinctness.)
+	const range = []
+	if (inclusive) {
+		range.push(a)
+	}
+	if (a < b) {
+		// Ordered lowest to highest
+		let current = a + 1
+		while (current < b) {
+			range.push(current)
+			current += 1
+		}
+	} else {
+		// Ordered highest to lowest
+		let current = a - 1
+		while (current > b) {
+			range.push(current)
+			current -= 1
+		}
+	}
+	if (inclusive) {
+		range.push(b)
+	}
+
+	return range
+}
+
+// Takes a string range like `"1-4"` and returns an array of boundary integers: `[1,4]`.
+//
+// If the string contains just a single number (no range), it will return a single-integer array.
+//
+// Strings containing multiple ranges, e.g. `"1-4-3"`, are officially unsupported, but it tries to
+// recover from it by returning the first and last elements of the range. (It does not use min/max
+// cleverness to pluck out the highest and lowest numbers in the string, because we support
+// reverse-order ranges such as `"6-1"`, and determining order intent from multiple-range strings
+// isn't compatible with this.)
+//
+// Examples:
+// - `"1"`   => `[1]`
+// - `"1-3"` => `[1,3]`
+// - `"3-1"` => `[3,1]`
+// - `"1-3-5"` => `[1,5]` // Don't do this!
+//
+// This method is not broadly useful, but it's still exported so we can test it.
+export const splitRangeToIntegers = (range) => {
+	let array = []
+	if (range.includes('-')) {
+		const splitRange = range.split('-')
+		// TODO: Enable the next block if logger-importing is solved:
+		// if (splitRange.length > 2) {
+		// 	logger.warn(`splitRangeToIntegers() was passed a multiple-range string. The result may
+		// 							be unexpected.`)
+		// }
+		array = [splitRange[0], splitRange.pop()]
+	} else {
+		array = [range]
+	}
+	return array.map((i) => parseInt(i, 10))
+}
+
+// Converts an integer range shorthand syntax to an array of unique integers.
+//
+// It receives a string like `"1-5,10-15,19"` and returns all the integers we think that range
+// intends to describe. In that case: `[1,2,3,4,5,10,11,12,13,14,15,19]`.
+export const expandRangeOfIntegers = (rangeShorthand) => {
+	let expandedRange = []
+	rangeShorthand.split(',').forEach((segment) => {
+		let splitSegments = splitRangeToIntegers(segment)
+		if (splitSegments.length === 2) {
+			splitSegments = generateIntegersBetween(splitSegments[0], splitSegments[1])
+		}
+		expandedRange = expandedRange.concat(splitSegments)
+	})
+	return uniqueArray(expandedRange)
+}

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -5,17 +5,31 @@
 // out how to safely do so.
 // ------------------------------------------------------------------------------------------------
 
-// Given an array of items, returns a new array with only the unique items.
-//
-// TODO: This could have quite a bit more safety and error-checking built in.
+/**
+ * Given an array of items, returns a new array with only the unique items.
+ *
+ * TODO: This could have quite a bit more safety and error-checking built in.
+ *
+ * @param  {Array} array An array of elements.
+ * @return {Array}       The input array, reduced to unique elements.
+ */
 export const uniqueArray = (array) => [...new Set(array)]
 
-// Given two integers, generates all the integers in between.
-//
-// By default, will include the original two boundary integers. To exclude them, set
-// `inclusive: false` in the third (options) argument.
-//
-// This function does not do type coercion, so boundary arguments must be integers.
+/**
+ * Given two integers, generates all the integers in between. Works both low-high or high-low.
+ *
+ * By default, will include the original two boundary integers. To exclude them, set
+ * `inclusive: false` in the third (options) argument.
+ *
+ * This function does not do type coercion, so boundary arguments must be integers.
+ *
+ * @param  {Integer}         a         First number of the set.
+ * @param  {Integer}         b         Second number of the set.
+ * @param  {Object<Boolean>} inclusive If true, includes the boundary arguments in the resulting
+ *                                     integer list. If false, does not. Defaults true.
+ * @return {Array[Integer]}            Array of integers between (and optionally including) the two
+ *                                     numbers provided.
+ */
 export const generateIntegersBetween = (a, b, { inclusive = true } = {}) => {
 	// Bail out early if we weren't passed integers
 	if (!Number.isInteger(a) || !Number.isInteger(b)) {
@@ -56,23 +70,29 @@ export const generateIntegersBetween = (a, b, { inclusive = true } = {}) => {
 	return range
 }
 
-// Takes a string range like `"1-4"` and returns an array of boundary integers: `[1,4]`.
-//
-// If the string contains just a single number (no range), it will return a single-integer array.
-//
-// Strings containing multiple ranges, e.g. `"1-4-3"`, are officially unsupported, but it tries to
-// recover from it by returning the first and last elements of the range. (It does not use min/max
-// cleverness to pluck out the highest and lowest numbers in the string, because we support
-// reverse-order ranges such as `"6-1"`, and determining order intent from multiple-range strings
-// isn't compatible with this.)
-//
-// Examples:
-// - `"1"`   => `[1]`
-// - `"1-3"` => `[1,3]`
-// - `"3-1"` => `[3,1]`
-// - `"1-3-5"` => `[1,5]` // Don't do this!
-//
-// This method is not broadly useful, but it's still exported so we can test it.
+/**
+ * Takes a string range like `"1-4"` and returns an array of boundary integers: `[1,4]`.
+ *
+ * If the string contains just a single number (no range), it will return a single-integer array.
+ *
+ * Strings containing multiple ranges, e.g. `"1-4-3"`, are officially unsupported, but it tries to
+ * recover from it by returning the first and last elements of the range. (It does not use min/max
+ * cleverness to pluck out the highest and lowest numbers in the string, because we support
+ * reverse-order ranges such as `"6-1"`, and determining order intent from multiple-range strings
+ * isn't compatible with this.)
+ *
+ * Examples:
+ * - `"1"`   => `[1]`
+ * - `"1-3"` => `[1,3]`
+ * - `"3-1"` => `[3,1]`
+ * - `"1-3-5"` => `[1,5]` // Don't do this!
+ *
+ * This method is not broadly useful, but it's still exported so we can test it.
+ *
+ * @param  {String} range   A range of two numbers such as `"1-5"`.
+ * @return {Array[Integer]} An array of the two numbers in the range, or just one number if that's
+ *                          all that was provided.
+ */
 export const splitRangeToIntegers = (range) => {
 	let array = []
 	if (range.includes('-')) {
@@ -89,10 +109,16 @@ export const splitRangeToIntegers = (range) => {
 	return array.map((i) => parseInt(i, 10))
 }
 
-// Converts an integer range shorthand syntax to an array of unique integers.
-//
-// It receives a string like `"1-5,10-15,19"` and returns all the integers we think that range
-// intends to describe. In that case: `[1,2,3,4,5,10,11,12,13,14,15,19]`.
+/**
+ * Converts an integer range shorthand syntax to an array of unique integers.
+ *
+ * It receives a string like `"1-5,10-15,19"` and returns all the integers we think that range
+ * intends to describe. In that case: `[1,2,3,4,5,10,11,12,13,14,15,19]`.
+ *
+ * @param  {String} rangeShorthand Shorthand representation of a series of ranges, e.g.
+ *                                 `"1-5,10-15,19"`,
+ * @return {Array[Integer]}        An array of all the numbers determined to be desired.
+ */
 export const expandRangeOfIntegers = (rangeShorthand) => {
 	let expandedRange = []
 	rangeShorthand.split(',').forEach((segment) => {

--- a/src/lib/utils/ingest.js
+++ b/src/lib/utils/ingest.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export */
+
+import 'module-alias/register'
+
+import config from '%src/config'
+
+export const chooseAvailableInternalStream = () => `${config.INTERNAL_STREAM_ADDRESS}:${config.INTERNAL_STREAM_PORT_RANGE[0]}`

--- a/src/scripts/ingest.js
+++ b/src/scripts/ingest.js
@@ -1,0 +1,38 @@
+import 'module-alias/register'
+import { spawn } from 'child_process'
+
+import logger from '%src/lib/logger'
+import { chooseAvailableInternalStream } from '%src/lib/utils/ingest'
+
+const ingestSource = process.argv[2]
+if (!ingestSource) {
+	logger.error('You must specify an input source.')
+	process.exit()
+}
+
+const availableStreamAddress = chooseAvailableInternalStream()
+
+logger.info(`Starting ingestion of "${ingestSource}"...`)
+
+const ffmpeg = spawn('ffmpeg', [
+	'-hide_banner',
+	'-loglevel', 'panic',
+	'-re',
+	'-i', ingestSource, // This is actually profoundly unsafe; we should sanitize it
+	'-f', 'mpegts',
+	`udp://${availableStreamAddress}`,
+])
+
+ffmpeg.stdout.on('data', (data) => {
+	logger.info(data)
+})
+
+// Annoyingly, ffmpeg actually sends all its expected output to stderr...
+ffmpeg.stderr.on('data', (data) => {
+	logger.error(data)
+})
+
+ffmpeg.on('close', () => {
+	logger.info(`Finished ingestion of "${ingestSource}".`)
+	process.exit()
+})

--- a/src/scripts/showInternalStreamPool.js
+++ b/src/scripts/showInternalStreamPool.js
@@ -1,0 +1,8 @@
+import 'module-alias/register'
+
+import config from '%src/config'
+import logger from '%src/lib/logger'
+
+const allInternalStreamConfigurations = config.INTERNAL_STREAM_PORT_RANGE.map((port) => `${config.INTERNAL_STREAM_ADDRESS}:${port}`)
+
+logger.info(`All configured address/port combinations:\n${allInternalStreamConfigurations.join('\n')}`)


### PR DESCRIPTION
## Description
This PR adds FFmpeg to our tech stack and demonstrates a very simple script that takes an input address (file or network stream) and proxies it through FFmpeg to an available internal network stream, configurable via `.env`.

To accomplish that though, it adds a bunch (possibly too much) of support infrastructure.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation: TODO: Needs JSDoc format for tests
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. Modify `.env` to add the new variables from `.env.template`
2. `yarn ingest:showInternalStreamPool` should list out all the address/port combinations from ☝️
3. `yarn ingest {source}` should open a stream to the first port from that list; for now, a good `{source}` would be an HDHomeRun stream address like `http://<device ip>:5004/auto/v<channel number>`
4. To verify ☝️ is happening, open a new tab and run `ffplay {address}` where `{address}` is the first address dumped out by `yarn ingest:showInternalStreamPool` (which is the one it will be streaming to)

## Deploy Notes
1. Must modify `.env` to add the new variables from `.env.template`
2. Must install FFmpeg; this is outside of the scope of the instructions.

## Related Issues
Related to #14
