### PR TITLE
Silences Winston console output during tests

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,6 +4,17 @@ This project uses Jest for testing.  All new [contributions](docs/CONTRIBUTING.m
 
 **Please review [this excellent guide](https://github.com/goldbergyoni/javascript-testing-best-practices) on JavaScript testing best practices.**
 
+## Test Command
+
+To test the project, run:
+
+```
+yarn test
+```
+
+This will display the test results, but not other logging output from the code by default. To override this add `--no-silent`.
+
+
 ## Test Locations
 
 We have a few types of test, which should be placed in different places depending on the type of test.

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,8 @@ const { getModuleAliasesForJest } = require('./lib/utils/moduleAlias')
 
 const settings = {
 	moduleNameMapper: getModuleAliasesForJest(),
+	setupFiles: ['./lib/utils/jest.setup.js'],
+	silent: true,
 }
 
 module.exports = settings

--- a/lib/utils/jest.setup.js
+++ b/lib/utils/jest.setup.js
@@ -1,0 +1,18 @@
+import { NullConsole } from '@jest/console'
+import { transports } from 'winston'
+import logger from '%src/lib/logger'
+
+const getConsoleTransport = () => logger.transports.find(
+	(transport) => transport.constructor.name === transports.Console.name,
+)
+// eslint-disable-next-line no-console
+const isJestSilent = () => console.constructor.name === NullConsole.name
+
+// Respect Jest's silent configuration by silencing Winston's logging.
+// Can be overridden by specifying --no-silent on the command line.
+
+const consoleTransport = getConsoleTransport()
+
+if (consoleTransport) {
+	consoleTransport.silent = isJestSilent()
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "winston": "^3.2.1",
     "@tvkitchen/base-constants": "^1.0.0",
     "@tvkitchen/base-classes": "^1.1.0",
-    "@tvkitchen/base-errors": "^1.0.0"
+    "@tvkitchen/base-errors": "^1.0.0",
+    "@jest/console": "^25.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",


### PR DESCRIPTION
## Description
This PR toggles the silence option on the Winston console transport stream when the `NODE_ENV` is `test`. This environment variable is automatically set when running `yarn test`, so this silences the logger. It's one of several competing solutions discussed in [this StackOverflow question](https://stackoverflow.com/questions/38363292/disable-winston-logging-when-running-unit-tests).

Downsides:

1. it intermingles a test-specific flag with the production code instead of doing so in a Jest setup file;
2. it doesn't follow Jest's `--silent` flag on the command line (should it?).

Other StackOverflow solutions address those downsides. Could investigate adding to a Jest setup further if needed. One line PR was tempting.

## Due Diligence Checklist
- [x] Consolidated commits

## Steps to Test
1. Add `logger.info('whee')` to any test file.
2. Run `yarn test`. You should expect to see no output from the logging statement.
3. Run `yarn test --no-silent`. You should expect to see output from the statement.

## Related Issues
Resolves #49 
