### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+logs
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:14-alpine
+
+WORKDIR /usr/src/app
+
+COPY package.json ./
+COPY yarn.lock ./
+
+RUN yarn
+
+COPY . .
+
+RUN apk add  --no-cache ffmpeg
+
+CMD [ "npm", "start" ]


### PR DESCRIPTION
This adds a Dockerfile and .dockerignore file to allow the project to be built as a docker image. This is the first of several incremental changes for Docker readiness outlined in #54.

## Due Diligence Checklist
- [x] Consolidated commits

## Steps to Test
1. `docker build .`
2. `docker run --env-file=.env <image hash>`

## Related Issues
Begins work outlined in #54
