### PR TITLE
Create HTTP ingestion engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "@tvkitchen/base-constants": "^1.0.0",
     "@tvkitchen/base-classes": "^1.1.0",
     "@tvkitchen/base-errors": "^1.0.0",
-    "@jest/console": "^25.1.0"
+    "@jest/console": "^25.1.0",
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",

--- a/src/components/ingestion/HttpIngestionEngine.js
+++ b/src/components/ingestion/HttpIngestionEngine.js
@@ -1,0 +1,51 @@
+import { PassThrough } from 'stream'
+import fetch from 'node-fetch'
+import AbstractIngestionEngine from '%src/components/ingestion/AbstractIngestionEngine'
+
+/**
+ * The HttpIngestionEngine handles processing a HTTP video stream. It is a concrete
+ * implementation of AbstractIngestionEngine, which reads in a stream,
+ * converts it into an MPEG-TS stream represented as a series of Payloads,
+ * and then pipes that to Kafka.
+ *
+ * @extends AbstractIngestionEngine
+ */
+class HttpIngestionEngine extends AbstractIngestionEngine {
+	// The URL of the stream to read by the engine
+	url = null
+
+	/**
+	 * Create a HttpIngestionEngine.
+	 *
+	 * @param  {string}  url The url of the stream to be ingested
+	 */
+	constructor(url) {
+		super()
+		if (!url) {
+			throw new Error(
+				'HttpIngestionEngine must be instantiated with a stream URL',
+			)
+		}
+
+		this.url = url
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	getInputStream = () => {
+		const stream = new PassThrough()
+
+		fetch(this.url)
+			.then((response) => {
+				response.body.pipe(stream)
+			})
+			.catch((err) => {
+				stream.emit('error', err)
+			})
+
+		return stream
+	}
+}
+
+export default HttpIngestionEngine

--- a/src/components/ingestion/__test__/HttpIngestionEngine.unit.test.js
+++ b/src/components/ingestion/__test__/HttpIngestionEngine.unit.test.js
@@ -1,0 +1,48 @@
+import nock from 'nock'
+import HttpIngestionEngine from '../HttpIngestionEngine'
+
+describe('HttpIngestionEngine', () => {
+	describe('constructor', () => {
+		it('should throw an error when called without a URL', () => {
+			expect(() => {
+				new HttpIngestionEngine() // eslint-disable-line no-new
+			}).toThrow(Error)
+		})
+	})
+
+	describe('getInputStream', () => {
+		it('it should stream the client request body', () => {
+			const base = 'http://example.com'
+			const file = '/test.ts'
+			const body = 'it worked!'
+
+			nock(base).get(file).reply(200, body)
+
+			const fileEngine = new HttpIngestionEngine(`${base}${file}`)
+
+			const inputStream = fileEngine.getInputStream()
+
+			return expect(
+				new Promise((resolve) => inputStream.on('data', resolve)),
+			).resolves.toEqual(Buffer.from(body))
+		})
+
+		it('it should pass on errors correctly', () => {
+			const base = 'http://example.com'
+			const file = '/error-test.ts'
+			const message = 'it didn\'t work!'
+
+			nock(base).get(file).replyWithError({
+				message,
+			})
+
+			const fileEngine = new HttpIngestionEngine(`${base}${file}`)
+
+			const inputStream = fileEngine.getInputStream()
+
+			return expect(
+				new Promise((resolve, reject) => inputStream.on('error', reject)),
+			).rejects.toHaveProperty('name', 'FetchError')
+		})
+	})
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3757,6 +3757,11 @@ node-environment-flags@^1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
## Description
Creates a HTTP ingestion engine that can serve as a base for a HDHomeRun engine.

## Due Diligence Checklist
- [x] Tests
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Related Issues
Resolves #73